### PR TITLE
refactor(tests): use builder pattern for bootstraping application

### DIFF
--- a/bin/benches/benchmark.rs
+++ b/bin/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use convertible_couch::testing::arrangements::{bootstrap_application, ArgumentsBuilder};
+use convertible_couch::testing::arrangements::{ApplicationBuilder, ArgumentsBuilder};
 use convertible_couch_lib::{
     func,
     testing::fuzzing::{ComputerBuilder, Fuzzer},
@@ -62,7 +62,7 @@ fn change_primary_display_and_default_speaker(criterion: &mut Criterion) {
                                 .with_an_alternative_one_named(alternative_speaker_name.clone())
                                 .build_computer();
 
-                            let application = bootstrap_application(computer);
+                            let application = ApplicationBuilder::new(computer).build();
 
                             let args = ArgumentsBuilder
                                 .change()
@@ -110,7 +110,7 @@ fn change_primary_display(criterion: &mut Criterion) {
                             .with_a_secondary_named(secondary_display_name.clone())
                             .build_computer();
 
-                        let application = bootstrap_application(computer);
+                        let application = ApplicationBuilder::new(computer).build();
 
                         let args = ArgumentsBuilder
                             .change()
@@ -152,7 +152,7 @@ fn change_default_speaker(criterion: &mut Criterion) {
                             .with_an_alternative_one_named(alternative_speaker_name.clone())
                             .build_computer();
 
-                        let application = bootstrap_application(computer);
+                        let application = ApplicationBuilder::new(computer).build();
 
                         let args = ArgumentsBuilder
                             .change()
@@ -194,7 +194,7 @@ fn get_infos_about_displays(criterion: &mut Criterion) {
                             .with_a_secondary_named(secondary_display_name.clone())
                             .build_computer();
 
-                        let application = bootstrap_application(computer);
+                        let application = ApplicationBuilder::new(computer).build();
 
                         let args = ArgumentsBuilder.info().displays_only().build();
 
@@ -233,7 +233,7 @@ fn get_infos_about_speakers(criterion: &mut Criterion) {
                             .with_an_alternative_one_named(alternative_speaker_name.clone())
                             .build_computer();
 
-                        let application = bootstrap_application(computer);
+                        let application = ApplicationBuilder::new(computer).build();
 
                         let args = ArgumentsBuilder.info().speakers_only().build();
 
@@ -287,7 +287,7 @@ fn get_infos_about_displays_and_speakers(criterion: &mut Criterion) {
                                 .with_an_alternative_one_named(alternative_speaker_name.clone())
                                 .build_computer();
 
-                            let application = bootstrap_application(computer);
+                            let application = ApplicationBuilder::new(computer).build();
 
                             let args = ArgumentsBuilder.info().displays_and_speakers().build();
 

--- a/bin/src/testing/arrangements.rs
+++ b/bin/src/testing/arrangements.rs
@@ -17,23 +17,33 @@ use crate::{
     },
 };
 
-pub fn bootstrap_application(
+pub struct ApplicationBuilder {
     computer: FuzzedComputer,
-) -> Application<
-    CurrentFuzzedDisplaysSettingsApi,
-    CurrentFuzzedSpeakersSettingsApi,
-    CurrentDisplaysSettings<CurrentFuzzedDisplaysSettingsApi>,
-    CurrentSpeakersSettings<CurrentFuzzedSpeakersSettingsApi>,
-> {
-    Application::<
+}
+
+impl ApplicationBuilder {
+    pub fn new(computer: FuzzedComputer) -> Self {
+        Self { computer }
+    }
+
+    pub fn build(
+        self,
+    ) -> Application<
         CurrentFuzzedDisplaysSettingsApi,
         CurrentFuzzedSpeakersSettingsApi,
         CurrentDisplaysSettings<CurrentFuzzedDisplaysSettingsApi>,
         CurrentSpeakersSettings<CurrentFuzzedSpeakersSettingsApi>,
-    >::bootstrap(
-        computer.displays_settings_api,
-        computer.speakers_settings_api,
-    )
+    > {
+        Application::<
+            CurrentFuzzedDisplaysSettingsApi,
+            CurrentFuzzedSpeakersSettingsApi,
+            CurrentDisplaysSettings<CurrentFuzzedDisplaysSettingsApi>,
+            CurrentSpeakersSettings<CurrentFuzzedSpeakersSettingsApi>,
+        >::bootstrap(
+            self.computer.displays_settings_api,
+            self.computer.speakers_settings_api,
+        )
+    }
 }
 
 pub struct ArgumentsBuilder;

--- a/bin/tests/change_displays_and_speakers.rs
+++ b/bin/tests/change_displays_and_speakers.rs
@@ -1,6 +1,6 @@
 use convertible_couch::{
     application::{ApplicationChangeResult, ApplicationResult},
-    testing::arrangements::{bootstrap_application, ArgumentsBuilder},
+    testing::arrangements::{ApplicationBuilder, ArgumentsBuilder},
 };
 use convertible_couch_lib::{
     displays_settings::DisplaysSettingsResult,
@@ -30,7 +30,7 @@ fn it_should_change_primary_display_and_default_speaker() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -83,7 +83,7 @@ fn it_should_change_primary_display_and_default_speaker_back_and_forth() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/change_displays_and_speakers_windows.rs
+++ b/bin/tests/change_displays_and_speakers_windows.rs
@@ -1,4 +1,4 @@
-use convertible_couch::testing::arrangements::{bootstrap_application, ArgumentsBuilder};
+use convertible_couch::testing::arrangements::{ApplicationBuilder, ArgumentsBuilder};
 use convertible_couch_lib::{
     func,
     testing::fuzzing::{ComputerBuilder, Fuzzer},
@@ -28,7 +28,7 @@ fn it_should_report_a_displays_settings_error() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -72,7 +72,7 @@ fn it_should_report_a_speakers_settings_error() {
         .for_which_setting_the_default_speaker_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/change_displays_only.rs
+++ b/bin/tests/change_displays_only.rs
@@ -1,7 +1,7 @@
 use convertible_couch::{
     application::{ApplicationChangeResult, ApplicationResult},
     testing::{
-        arrangements::{bootstrap_application, ArgumentsBuilder},
+        arrangements::{ApplicationBuilder, ArgumentsBuilder},
         assertions::assert_that_result_is_an_error_who_starts_with,
     },
 };
@@ -27,7 +27,7 @@ fn it_should_swap_the_desktop_display_with_the_couch_display() {
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -66,7 +66,7 @@ fn it_should_swap_the_couch_display_with_the_desktop_display() {
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -108,7 +108,7 @@ fn it_should_swap_the_desktop_display_with_the_couch_display_when_the_computer_h
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -147,7 +147,7 @@ fn it_should_swap_the_couch_display_with_the_desktop_display_has_an_internal_dis
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -189,7 +189,7 @@ fn it_should_validate_the_desktop_display() {
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -224,7 +224,7 @@ fn it_should_validate_the_couch_display() {
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -263,7 +263,7 @@ fn it_should_validate_both_desktop_and_couch_displays() {
         .with_a_secondary_named(secondary_display_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -298,7 +298,7 @@ fn it_should_handle_the_case_when_it_fails_to_get_the_primary_display_name() {
         .for_which_getting_the_primary_display_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/change_displays_only_windows.rs
+++ b/bin/tests/change_displays_only_windows.rs
@@ -2,7 +2,7 @@
 
 use convertible_couch::{
     application::{ApplicationChangeResult, ApplicationResult},
-    testing::arrangements::{bootstrap_application, ArgumentsBuilder},
+    testing::arrangements::{ApplicationBuilder, ArgumentsBuilder},
 };
 use convertible_couch_lib::{
     displays_settings::DisplaysSettingsResult,
@@ -42,7 +42,7 @@ fn it_should_report_committed_displays_settings_changes_errors(
         .for_which_committing_the_display_changes_fails_with(disp_change)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -76,7 +76,7 @@ fn it_should_report_displays_settings_changes_errors(
         .for_which_changing_the_display_settings_fails_with(disp_change)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -103,7 +103,7 @@ fn it_should_ask_for_reboot_when_committing_displays_settings_requires_it() {
         .for_which_committing_the_display_changes_fails_with(DISP_CHANGE_RESTART)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -143,7 +143,7 @@ fn it_should_ask_for_reboot_when_changing_displays_settings_requires_it() {
         .for_which_changing_the_display_settings_fails_with(DISP_CHANGE_RESTART)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -183,7 +183,7 @@ fn it_should_report_get_display_config_buffer_sizes_errors() {
         .for_which_getting_display_config_buffer_sizes_fails_with(ERROR_INVALID_PARAMETER)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -218,7 +218,7 @@ fn it_should_report_query_display_config_errors() {
         .for_which_querying_display_config_fails_with(ERROR_INVALID_PARAMETER)
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -256,7 +256,7 @@ fn it_should_handle_the_case_of_a_display_being_not_possible_to_enum_display_set
         )
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/change_speakers_only.rs
+++ b/bin/tests/change_speakers_only.rs
@@ -1,6 +1,6 @@
 use convertible_couch::{
     application::{ApplicationChangeResult, ApplicationResult},
-    testing::arrangements::{bootstrap_application, ArgumentsBuilder},
+    testing::arrangements::{ApplicationBuilder, ArgumentsBuilder},
 };
 use convertible_couch_lib::{
     func,
@@ -24,7 +24,7 @@ fn it_should_change_the_default_speaker() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -62,7 +62,7 @@ fn it_should_change_the_default_speaker_back_and_forth() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -107,7 +107,7 @@ fn it_should_validate_the_desktop_and_couch_speaker_name() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -140,7 +140,7 @@ fn it_should_validate_the_desktop_speaker_name() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -173,7 +173,7 @@ fn it_should_validate_the_couch_speaker_name() {
         .with_an_alternative_one_named(alternative_speaker_name.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/change_speakers_only_windows.rs
+++ b/bin/tests/change_speakers_only_windows.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 
-use convertible_couch::testing::arrangements::{bootstrap_application, ArgumentsBuilder};
+use convertible_couch::testing::arrangements::{ApplicationBuilder, ArgumentsBuilder};
 use convertible_couch_lib::{
     func,
     testing::fuzzing::{ComputerBuilder, Fuzzer},
@@ -23,7 +23,7 @@ fn it_should_return_an_error_if_getting_the_speakers_count_fails() {
         .for_which_getting_the_speakers_count_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -58,7 +58,7 @@ fn it_should_return_an_error_if_getting_the_speakers_fails() {
         .for_which_getting_the_speakers_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -93,7 +93,7 @@ fn it_should_return_an_error_if_getting_the_current_default_speaker_fails() {
         .for_which_getting_the_default_speaker_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()
@@ -128,7 +128,7 @@ fn it_should_return_an_error_if_setting_the_default_speaker_fails() {
         .for_which_setting_the_default_speaker_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder
         .change()

--- a/bin/tests/info.rs
+++ b/bin/tests/info.rs
@@ -1,6 +1,6 @@
 use convertible_couch::{
     application::{ApplicationInfoResult, ApplicationResult},
-    testing::arrangements::{bootstrap_application, ArgumentsBuilder},
+    testing::arrangements::{ApplicationBuilder, ArgumentsBuilder},
 };
 use convertible_couch_lib::{
     displays_settings::DisplayInfo,
@@ -34,7 +34,7 @@ fn it_should_get_informations_about_displays_and_speakers() {
         .with_an_alternative_one_named(alternative_speaker_name_2.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder.info().displays_and_speakers().build();
 
@@ -95,7 +95,7 @@ fn it_should_get_informations_about_displays_only() {
         .with_a_secondary_named(secondary_display_name_2.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder.info().displays_only().build();
 
@@ -143,7 +143,7 @@ fn it_should_get_informations_about_speakers_only() {
         .with_an_alternative_one_named(alternative_speaker_name_2.clone())
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder.info().speakers_only().build();
 

--- a/bin/tests/info_speakers_only_windows.rs
+++ b/bin/tests/info_speakers_only_windows.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 
-use convertible_couch::testing::arrangements::{bootstrap_application, ArgumentsBuilder};
+use convertible_couch::testing::arrangements::{ApplicationBuilder, ArgumentsBuilder};
 use convertible_couch_lib::{
     func,
     testing::fuzzing::{ComputerBuilder, Fuzzer},
@@ -23,7 +23,7 @@ fn it_should_return_an_error_if_getting_the_speakers_count_fails() {
         .for_which_getting_the_speakers_count_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder.info().speakers_only().build();
 
@@ -55,7 +55,7 @@ fn it_should_return_an_error_if_getting_the_speakers_fails() {
         .for_which_getting_the_speakers_fails()
         .build_computer();
 
-    let mut application = bootstrap_application(computer);
+    let mut application = ApplicationBuilder::new(computer).build();
 
     let args = ArgumentsBuilder.info().speakers_only().build();
 


### PR DESCRIPTION
refactor(tests): use builder pattern for bootstraping application

Using the builder pattern will ease the extension of the tests.